### PR TITLE
Add new state StillState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Custom files
+nuget.config
+
 # User-specific files
 *.rsuser
 *.suo

--- a/Nt.Automaton.Domain/Nt.Automaton.Domain.csproj
+++ b/Nt.Automaton.Domain/Nt.Automaton.Domain.csproj
@@ -12,6 +12,7 @@
 	<PackageTags>automate ; automaton ; states</PackageTags>
 	<PackageReleaseNotes>First official release</PackageReleaseNotes>
 	<PackageVersion>1.0.0</PackageVersion>
+	<PackageId>Nt.Automaton</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Nt.Automaton.Domain/StateAutomaton.cs
+++ b/Nt.Automaton.Domain/StateAutomaton.cs
@@ -8,7 +8,7 @@ namespace Nt.Automaton
     /// Represents an automaton
     /// </summary>
     /// <param name="initialState">Initial state of the automaton</param>
-    public class StateAutomaton<T>(State<T> initialState) : IAutomaton<T>
+    public class StateAutomaton<T>(IState<T> initialState) : IAutomaton<T>
     {
         public IState<T> InitialState { get; } = initialState;
         public IState<T> CurrentState { get; private set; } = initialState;

--- a/Nt.Automaton.Domain/States/IState.cs
+++ b/Nt.Automaton.Domain/States/IState.cs
@@ -7,8 +7,22 @@ namespace Nt.Automaton.States
     public interface IState<T>
     {
         IAction<T>? Action { get; }
+
         IState<T> Read(IAutomatonToken<T> token);
         void AddTransition(ITransition<T> transition);
-        public void AddTransitions(ICollection<ITransition<T>> transitions);
+
+        /// <summary>
+        /// Triggers the <see cref="StateReached"/> event
+        /// </summary>
+        /// <param name="args">Event arguments</param>
+        void OnReached(StateEventArgs<T> args);
+        /// <summary>
+        /// Triggers the <see cref="StateLeft"/> event
+        /// </summary>
+        /// <param name="args"></param>
+        void OnLeft(StateEventArgs<T> args);
+
+        event EventHandler<StateEventArgs<T>> StateReached;
+        event EventHandler<StateEventArgs<T>> StateLeft;
     }
 }

--- a/Nt.Automaton.Domain/States/IState.cs
+++ b/Nt.Automaton.Domain/States/IState.cs
@@ -1,5 +1,6 @@
 ﻿using Nt.Automaton.Actions;
 using Nt.Automaton.Tokens;
+using Nt.Automaton.Transitions;
 
 namespace Nt.Automaton.States
 {
@@ -7,5 +8,7 @@ namespace Nt.Automaton.States
     {
         IAction<T>? Action { get; }
         IState<T> Read(IAutomatonToken<T> token);
+        void AddTransition(ITransition<T> transition);
+        public void AddTransitions(ICollection<ITransition<T>> transitions);
     }
 }

--- a/Nt.Automaton.Domain/States/State.cs
+++ b/Nt.Automaton.Domain/States/State.cs
@@ -98,7 +98,6 @@ namespace Nt.Automaton.States
         /// <exception cref="NoDefaultStateException">It might be that no default state was set for this state</exception>
         public IState<T> Read(IAutomatonToken<T> token)
         {
-            if (DefaultState == null) throw new NoDefaultStateException();
             foreach (var transition in Transitions)
             {
                 if (transition.Value == null) throw new NullTransitionTokenValue();
@@ -109,6 +108,7 @@ namespace Nt.Automaton.States
                     return transition.NewState;
                 }
             }
+            if (DefaultState == null) throw new NoDefaultStateException();
             DefaulAction?.Perform(token);
             DefaultState.Action?.Perform(token);
             return DefaultState;

--- a/Nt.Automaton.Domain/States/State.cs
+++ b/Nt.Automaton.Domain/States/State.cs
@@ -2,6 +2,7 @@
 using Nt.Automaton.States.Exceptions;
 using Nt.Automaton.Tokens;
 using Nt.Automaton.Transitions;
+using System.Transactions;
 
 namespace Nt.Automaton.States
 {
@@ -103,16 +104,56 @@ namespace Nt.Automaton.States
                 if (transition.Value == null) throw new NullTransitionTokenValue();
                 if (transition.Value.Equals(token.Value))
                 {
-                    transition.Action?.Perform(token);
-                    transition.NewState.Action?.Perform(token);
-                    return transition.NewState;
+                    return TargetNewState(transition, token);
                 }
             }
+            return TargetDefaultState(token);
+        }
+
+        private IState<T> TargetNewState(ITransition<T> transition, IAutomatonToken<T> token)
+        {
+            transition.Action?.Perform(token);
+            transition.NewState.Action?.Perform(token);
+
+            var args = new StateEventArgs<T>(transition);
+            OnLeft(args);
+            transition.NewState.OnReached(args);
+
+            return transition.NewState;
+        }
+
+        private IState<T> TargetDefaultState(IAutomatonToken<T> token)
+        {
             if (DefaultState == null) throw new NoDefaultStateException();
             DefaulAction?.Perform(token);
-            DefaultState.Action?.Perform(token);
-            return DefaultState;
-        }           
+            DefaultState?.Action?.Perform(token);
+
+            var args = new StateEventArgs<T>(new Transition<T>(token.Value, DefaultState!));
+            OnLeft(args);
+            DefaultState!.OnReached(args);
+
+            return DefaultState!;
+        }
+
+        public void OnReached(StateEventArgs<T> args)
+        {
+            StateReached?.Invoke(this, args);
+        }
+
+        public void OnLeft(StateEventArgs<T> args)
+        {
+            StateLeft?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Event triggered after a transition that targets this state is taken.
+        /// </summary>
+        public event EventHandler<StateEventArgs<T>> StateReached;
+
+        /// <summary>
+        /// Event triggered before a transition that departs from this state is taken.
+        /// </summary>
+        public event EventHandler<StateEventArgs<T>> StateLeft;
     }
 
 }

--- a/Nt.Automaton.Domain/States/StateEventArgs.cs
+++ b/Nt.Automaton.Domain/States/StateEventArgs.cs
@@ -1,0 +1,13 @@
+﻿using Nt.Automaton.Transitions;
+
+namespace Nt.Automaton.States
+{
+    public class StateEventArgs<T> : EventArgs
+    {
+        public ITransition<T>? Transition { get; }
+        public StateEventArgs(ITransition<T> transition)
+        {
+            Transition = transition;
+        }
+    }
+}

--- a/Nt.Automaton.Domain/States/StillState.cs
+++ b/Nt.Automaton.Domain/States/StillState.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace Nt.Automaton.States
 {
-    internal class StillState<T> : IState<T>
+    public class StillState<T> : IState<T>
     {
         public List<ITransition<T>> Transitions { get; } = [];
         public IState<T>? DefaultState { get; private set; }

--- a/Nt.Automaton.Domain/States/StillState.cs
+++ b/Nt.Automaton.Domain/States/StillState.cs
@@ -97,7 +97,6 @@ namespace Nt.Automaton.States
         /// <exception cref="NoDefaultStateException">It might be that no default state was set for this state</exception>
         public IState<T> Read(IAutomatonToken<T> token)
         {
-            if (DefaultState == null) throw new NoDefaultStateException();
             foreach (var transition in Transitions)
             {
                 if (transition.Value == null) throw new NullTransitionTokenValue();
@@ -107,6 +106,7 @@ namespace Nt.Automaton.States
                     return transition.NewState;
                 }
             }
+            if (DefaultState == null) throw new NoDefaultStateException();
             DefaulAction?.Perform(token);
             return DefaultState;
         }

--- a/Nt.Automaton.Domain/States/StillState.cs
+++ b/Nt.Automaton.Domain/States/StillState.cs
@@ -2,14 +2,13 @@
 using Nt.Automaton.States.Exceptions;
 using Nt.Automaton.Tokens;
 using Nt.Automaton.Transitions;
+using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Nt.Automaton.States
 {
-
-    /// <summary>
-    /// Represents a state within a finite state machine, including its transitions, actions, and default behavior.
-    /// </summary>
-    public class State<T> : IState<T>
+    internal class StillState<T> : IState<T>
     {
         public List<ITransition<T>> Transitions { get; } = [];
         public IState<T>? DefaultState { get; private set; }
@@ -19,12 +18,12 @@ namespace Nt.Automaton.States
         /// <summary>
         /// Initializes a new instance of the State class.
         /// </summary>
-        public State() { }
+        public StillState() { }
         /// <summary>
         /// Initializes a new instance of the State class with the specified action.
         /// </summary>
         /// <param name="action">The action to associate with this state.</param>
-        public State(IAction<T> action)
+        public StillState(IAction<T> action)
         {
             Action = action;
         }
@@ -34,18 +33,18 @@ namespace Nt.Automaton.States
         /// </summary>
         /// <param name="defaultState">The state to use as the default.</param>
         /// <returns>The current instance with the default state set.</returns>
-        public State<T> SetDefault(IState<T> defaultState)
+        public StillState<T> SetDefault(IState<T> defaultState)
         {
             DefaultState = defaultState;
             return this;
-        }     
+        }
         /// <summary>
         /// Sets the default state and action for this instance.
         /// </summary>
         /// <param name="defaultState">The state to use as the default.</param>
         /// <param name="defaultAction">The action to use as the default.</param>
         /// <returns>The current instance with the updated default state and action.</returns>
-        public State<T> SetDefault(IState<T> defaultState, IAction<T> defaultAction)
+        public StillState<T> SetDefault(IState<T> defaultState, IAction<T> defaultAction)
         {
             DefaultState = defaultState;
             DefaulAction = defaultAction;
@@ -105,14 +104,11 @@ namespace Nt.Automaton.States
                 if (transition.Value.Equals(token.Value))
                 {
                     transition.Action?.Perform(token);
-                    transition.NewState.Action?.Perform(token);
                     return transition.NewState;
                 }
             }
             DefaulAction?.Perform(token);
-            DefaultState.Action?.Perform(token);
             return DefaultState;
-        }           
+        }
     }
-
 }

--- a/Nt.Automaton.Domain/Tokens/AutomatonToken.cs
+++ b/Nt.Automaton.Domain/Tokens/AutomatonToken.cs
@@ -1,0 +1,7 @@
+﻿namespace Nt.Automaton.Tokens
+{
+    public class AutomatonToken<T>(T value) : IAutomatonToken<T>
+    {
+        public T Value { get; private set; } = value;
+    }
+}

--- a/Nt.Automaton.Domain/Tokens/IAutomatonToken.cs
+++ b/Nt.Automaton.Domain/Tokens/IAutomatonToken.cs
@@ -1,5 +1,6 @@
 ﻿namespace Nt.Automaton.Tokens
 {
+
     public interface IAutomatonToken<T>
     {
         T Value { get; }

--- a/Nt.Automaton.Tests/States/StateErrorException.cs
+++ b/Nt.Automaton.Tests/States/StateErrorException.cs
@@ -1,0 +1,4 @@
+﻿namespace Nt.Tests.Automaton.States
+{
+    internal class StateErrorException() : Exception() { }
+}

--- a/Nt.Automaton.Tests/States/StateTest.cs
+++ b/Nt.Automaton.Tests/States/StateTest.cs
@@ -1,0 +1,66 @@
+﻿using Nt.Automaton.States;
+using Nt.Automaton.Tokens;
+using Nt.Automaton.Transitions;
+
+namespace Nt.Tests.Automaton.States
+{
+    public class StateTest
+    {
+        [Fact]
+        public void State_DefaultTransition_ValidState()
+        {
+            var initial = new State<string>();
+            initial.SetDefault(initial);
+
+            var new_state = initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.Equal(initial, new_state);
+        }
+
+        [Fact]
+        public void State_MultipleDefaultTransition_ValidState()
+        {
+            var initial = new State<string>();
+            initial.SetDefault(initial);
+
+            IState<string> new_state = initial;
+            foreach (var letter in new List<string>(["a", "b", "c", "d", "e", "f"]))
+            {
+                new_state = initial.Read(new AutomatonToken<string>(letter));
+            }
+
+            Assert.Equal(initial, new_state);
+        }
+
+        [Fact]
+        public void State_DefaultTransition_StateActionPerformed()
+        {
+            var initial = new State<string>(new ThrowStateErrorAction());
+            initial.SetDefault(initial);
+
+            Assert.Throws<StateErrorException>(() => initial.Read(new AutomatonToken<string>("a")));
+        }
+
+        [Fact]
+        public void State_Transition_ValidState()
+        {
+            var initial = new State<string>();
+            var second = new State<string>();
+            initial.AddTransition(new Transition<string>("a", second));
+
+            var new_state = initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.Equal(second, new_state);
+        }
+
+        [Fact]
+        public void State_Transition_StateActionPerformed()
+        {
+            var initial = new State<string>();
+            var second = new State<string>(new ThrowStateErrorAction());
+            initial.AddTransition(new Transition<string>("a", second));
+
+            Assert.Throws<StateErrorException>(() => initial.Read(new AutomatonToken<string>("a")));
+        }
+    }
+}

--- a/Nt.Automaton.Tests/States/StateTest.cs
+++ b/Nt.Automaton.Tests/States/StateTest.cs
@@ -6,6 +6,8 @@ namespace Nt.Tests.Automaton.States
 {
     public class StateTest
     {
+        // Target states
+
         [Fact]
         public void State_DefaultTransition_ValidState()
         {
@@ -33,15 +35,6 @@ namespace Nt.Tests.Automaton.States
         }
 
         [Fact]
-        public void State_DefaultTransition_StateActionPerformed()
-        {
-            var initial = new State<string>(new ThrowStateErrorAction());
-            initial.SetDefault(initial);
-
-            Assert.Throws<StateErrorException>(() => initial.Read(new AutomatonToken<string>("a")));
-        }
-
-        [Fact]
         public void State_Transition_ValidState()
         {
             var initial = new State<string>();
@@ -53,6 +46,17 @@ namespace Nt.Tests.Automaton.States
             Assert.Equal(second, new_state);
         }
 
+        // Actions
+
+        [Fact]
+        public void State_DefaultTransition_StateActionPerformed()
+        {
+            var initial = new State<string>(new ThrowStateErrorAction());
+            initial.SetDefault(initial);
+
+            Assert.Throws<StateErrorException>(() => initial.Read(new AutomatonToken<string>("a")));
+        }
+
         [Fact]
         public void State_Transition_StateActionPerformed()
         {
@@ -61,6 +65,62 @@ namespace Nt.Tests.Automaton.States
             initial.AddTransition(new Transition<string>("a", second));
 
             Assert.Throws<StateErrorException>(() => initial.Read(new AutomatonToken<string>("a")));
+        }
+
+        // Events
+
+        [Fact]
+        public void State_DefaultTransition_LeftEventTriggered()
+        {
+            var initial = new State<string>();
+            bool left_triggered = false;
+            initial.SetDefault(initial);
+            initial.StateLeft += (state, token) => { left_triggered = true; };
+
+            initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.True(left_triggered);
+        }
+
+        [Fact]
+        public void State_DefaultTransition_ReachedEventTriggered()
+        {
+            var initial = new State<string>();
+            bool reached_triggered = false;
+            initial.SetDefault(initial);
+            initial.StateReached += (state, token) => { reached_triggered = true; };
+
+            initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.True(reached_triggered);
+        }
+
+        [Fact]
+        public void State_Transition_LeftEventTriggered()
+        {
+            var initial = new State<string>();
+            var second = new State<string>();
+            bool left_triggered = false;
+            initial.AddTransition(new Transition<string>("a", second));
+            initial.StateLeft += (state, token) => { left_triggered = true; };
+
+            initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.True(left_triggered);
+        }
+
+        [Fact]
+        public void State_Transition_ReachedEventTriggered()
+        {
+            var initial = new State<string>();
+            var second = new State<string>();
+            bool reached_triggered = false;
+            initial.AddTransition(new Transition<string>("a", second));
+            second.StateReached += (state, token) => { reached_triggered = true; };
+
+            initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.True(reached_triggered);
         }
     }
 }

--- a/Nt.Automaton.Tests/States/StillStateTest.cs
+++ b/Nt.Automaton.Tests/States/StillStateTest.cs
@@ -3,13 +3,71 @@ using System.Collections.Generic;
 using System.Text;
 using Nt.Automaton;
 using Nt.Automaton.States;
+using Nt.Automaton.Tokens;
+using Nt.Automaton.Transitions;
 
 namespace Nt.Tests.Automaton.States
 {
     public class StillStateTest
     {
+        [Fact]
+        public void StillState_DefaultTransition_ValidState()
+        {
+            var initial = new StillState<string>();
+            initial.SetDefault(initial);
 
+            var new_state = initial.Read(new AutomatonToken<string>("a"));
 
+            Assert.Equal(initial, new_state);
+        }
+
+        [Fact]
+        public void StillState_MultipleDefaultTransition_ValidState()
+        {
+            var initial = new StillState<string>();
+            initial.SetDefault(initial);
+
+            IState<string> new_state = initial;
+            foreach (var letter in new List<string>(["a", "b", "c", "d", "e", "f"]))
+            {
+                new_state = initial.Read(new AutomatonToken<string>(letter));
+            }
+
+            Assert.Equal(initial, new_state);
+        }
+
+        [Fact]
+        public void StillState_DefaultTransition_NoStateActionPerformed()
+        {
+            var initial = new StillState<string>(new ThrowStateErrorAction());
+            initial.SetDefault(initial);
+
+            // Should throw an exception if the state action is performed
+            initial.Read(new AutomatonToken<string>("a"));
+        }
+
+        [Fact]
+        public void StillState_Transition_ValidState()
+        {
+            var initial = new StillState<string>();
+            var second = new StillState<string>();
+            initial.AddTransition(new Transition<string>("a", second));
+
+            var new_state = initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.Equal(second, new_state);
+        }
+
+        [Fact]
+        public void StillState_Transition_NoStateActionPerformed()
+        {
+            var initial = new StillState<string>();
+            var second = new StillState<string>(new ThrowStateErrorAction());
+            initial.AddTransition(new Transition<string>("a", second));
+
+            // Should throw an exception if the state action is performed
+            initial.Read(new AutomatonToken<string>("a"));
+        }
 
     }
 }

--- a/Nt.Automaton.Tests/States/StillStateTest.cs
+++ b/Nt.Automaton.Tests/States/StillStateTest.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Nt.Automaton;
+using Nt.Automaton.States;
+
+namespace Nt.Tests.Automaton.States
+{
+    public class StillStateTest
+    {
+
+
+
+    }
+}

--- a/Nt.Automaton.Tests/States/StillStateTest.cs
+++ b/Nt.Automaton.Tests/States/StillStateTest.cs
@@ -10,6 +10,8 @@ namespace Nt.Tests.Automaton.States
 {
     public class StillStateTest
     {
+        // Target states
+
         [Fact]
         public void StillState_DefaultTransition_ValidState()
         {
@@ -37,16 +39,6 @@ namespace Nt.Tests.Automaton.States
         }
 
         [Fact]
-        public void StillState_DefaultTransition_NoStateActionPerformed()
-        {
-            var initial = new StillState<string>(new ThrowStateErrorAction());
-            initial.SetDefault(initial);
-
-            // Should throw an exception if the state action is performed
-            initial.Read(new AutomatonToken<string>("a"));
-        }
-
-        [Fact]
         public void StillState_Transition_ValidState()
         {
             var initial = new StillState<string>();
@@ -56,6 +48,18 @@ namespace Nt.Tests.Automaton.States
             var new_state = initial.Read(new AutomatonToken<string>("a"));
 
             Assert.Equal(second, new_state);
+        }
+
+        // Actions
+
+        [Fact]
+        public void StillState_DefaultTransition_NoStateActionPerformed()
+        {
+            var initial = new StillState<string>(new ThrowStateErrorAction());
+            initial.SetDefault(initial);
+
+            // Should throw an exception if the state action is performed
+            initial.Read(new AutomatonToken<string>("a"));
         }
 
         [Fact]
@@ -69,5 +73,60 @@ namespace Nt.Tests.Automaton.States
             initial.Read(new AutomatonToken<string>("a"));
         }
 
+        // Events
+
+        [Fact]
+        public void State_DefaultTransition_LeftEventTriggered()
+        {
+            var initial = new StillState<string>();
+            bool left_triggered = false;
+            initial.SetDefault(initial);
+            initial.StateLeft += (state, token) => { left_triggered = true; };
+
+            initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.True(left_triggered);
+        }
+
+        [Fact]
+        public void State_DefaultTransition_ReachedEventTriggered()
+        {
+            var initial = new StillState<string>();
+            bool reached_triggered = false;
+            initial.SetDefault(initial);
+            initial.StateReached += (state, token) => { reached_triggered = true; };
+
+            initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.True(reached_triggered);
+        }
+
+        [Fact]
+        public void State_Transition_LeftEventTriggered()
+        {
+            var initial = new StillState<string>();
+            var second = new StillState<string>();
+            bool left_triggered = false;
+            initial.AddTransition(new Transition<string>("a", second));
+            initial.StateLeft += (state, token) => { left_triggered = true; };
+
+            initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.True(left_triggered);
+        }
+
+        [Fact]
+        public void State_Transition_ReachedEventTriggered()
+        {
+            var initial = new StillState<string>();
+            var second = new StillState<string>();
+            bool reached_triggered = false;
+            initial.AddTransition(new Transition<string>("a", second));
+            second.StateReached += (state, token) => { reached_triggered = true; };
+
+            initial.Read(new AutomatonToken<string>("a"));
+
+            Assert.True(reached_triggered);
+        }
     }
 }

--- a/Nt.Automaton.Tests/States/ThrowStateErrorAction.cs
+++ b/Nt.Automaton.Tests/States/ThrowStateErrorAction.cs
@@ -1,0 +1,13 @@
+﻿using Nt.Automaton.Actions;
+using Nt.Automaton.Tokens;
+
+namespace Nt.Tests.Automaton.States
+{
+    internal class ThrowStateErrorAction : IAction<string>
+    {
+        public void Perform(IAutomatonToken<string> token)
+        {
+            throw new StateErrorException();
+        }
+    }
+}

--- a/Nt.Automaton.slnx
+++ b/Nt.Automaton.slnx
@@ -1,4 +1,10 @@
 <Solution>
+  <Folder Name="/Solution files/">
+    <File Path=".gitattributes" />
+    <File Path=".gitignore" />
+    <File Path="nuget.config" />
+    <File Path="README.md" />
+  </Folder>
   <Project Path="Nt.Automaton.Domain/Nt.Automaton.Domain.csproj" />
   <Project Path="Nt.Automaton.Tests/Nt.Automaton.Tests.csproj" Id="a5966a4f-dcda-4143-9460-3681b5877362" />
 </Solution>


### PR DESCRIPTION
This gives the Automaton two implementation of `Istate`
- `State` is a state that automatically performs state action when reached
- `StillState` is a state that let the user manually trigger the action once reached

More over, some events have been added
- When a state is leaving to an other state
- When a state has been reached from a transition (or default transition)